### PR TITLE
Add psmisc dependency

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -188,7 +188,7 @@ else
 fi
 
 ##install dependencies
-if ! yum -y install binutils gcc make patch libgomp glibc-headers glibc-devel kernel-headers kernel-devel dkms; then
+if ! yum -y install binutils gcc make patch libgomp glibc-headers glibc-devel kernel-headers kernel-devel dkms psmisc; then
   printf '%s\n' 'deploy.sh: Unable to install depdency packages' >&2
   exit 1
 fi


### PR DESCRIPTION
The killall command is used in some scripts (such as clean.sh) but this command is available only when psmisc is installed.
This patch add this package to the dependencies list.
