### PR TITLE
Add net-tools to dependencies

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -197,7 +197,7 @@ else
 fi
 
 ##install dependencies
-if ! yum -y install binutils gcc make patch libgomp glibc-headers glibc-devel kernel-headers kernel-devel dkms psmisc; then
+if ! yum -y install binutils gcc make patch libgomp glibc-headers glibc-devel kernel-headers kernel-devel dkms psmisc net-tools; then
   printf '%s\n' 'deploy.sh: Unable to install depdency packages' >&2
   exit 1
 fi


### PR DESCRIPTION
When you start the installation with a centos minimal, net-tools must be installed with dependencies
